### PR TITLE
FIX: no-analysis version file, malformed id

### DIFF
--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -427,7 +427,7 @@ def make_release(
     gvl_attrib = GlobalVersion_TcGVL_root.find(".//GVL").attrib
 
     try:
-        gvl_attrib["Id"] = str(uuid.uuid4())
+        gvl_attrib["Id"] = f"{{{uuid.uuid4()}}}"
     except KeyError:
         raise RuntimeError("Could not find Id attribute in GVL tag")
 

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -384,10 +384,12 @@ def make_release(
     # company_tag = plcproj_root.find('.//Company', nsmap)
     # author_tag = plcproj_root.find('.//Author', nsmap)
     title_tag = plcproj_root.find(".//Title", nsmap)
+    released_tag = plcproj_root.find(".//Released", nsmap)
 
-    if None in (projectVersion_tag, title_tag):
+    if None in (projectVersion_tag, title_tag, released_tag):
         err = (
-            "Did not find a plc project version tag or a title tag! "
+            "Did not find at least one of the plc project version tag, "
+            "title tag, or released tag! "
             "Did you forgot to set the plc project version to 0.0.0 "
             "or select an appropriate project title in TwinCAT?"
         )
@@ -397,6 +399,7 @@ def make_release(
     # Adding version string to plcproj
 
     projectVersion_tag.text = version_string
+    released_tag.text = "true"
 
     # To make this verson number available in the PLC runtime,
     # we must add the Version/Global_Version.TcGVL to the project
@@ -455,6 +458,7 @@ def make_release(
         "stLibVersion_{title} : ST_LibVersion := "
         "(iMajor := {iMajor}, iMinor := {iMinor}, "
         "iBuild := {iBuild}, iRevision := {iRevision}, "
+        "nFlags := 1, "
         "sVersion := '{sVersion}');"
     )
     replacement_string = fmt.format(

--- a/tc_release/tcgvl.txt
+++ b/tc_release/tcgvl.txt
@@ -5,8 +5,8 @@
 {attribute 'linkalways'}
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
-	{attribute 'const_non_replaced'}
-	stLibVersion_LCLS_General : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
+    {attribute 'const_non_replaced'}
+    stLibVersion_LCLS_General : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/tc_release/tcgvl.txt
+++ b/tc_release/tcgvl.txt
@@ -1,11 +1,12 @@
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.10">
-  <GVL Name="Global_Version" Id="{c1e6c8db-11ef-4bd5-8510-07e605ee5d06}">
+<TcPlcObject Version="1.1.0.1">
+  <GVL Name="Global_Version" Id="{93e7903e-5285-4a46-bc87-ab19c31cba8b}">
     <Declaration><![CDATA[{attribute 'TcGenerated'}
+{attribute 'no-analysis'}
+{attribute 'linkalways'}
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
-    {attribute 'const_non_replaced'}
-    {attribute 'linkalways'}
-    stLibVersion_LCLS_General : ST_LibVersion := (iMajor := 0, iMinor := 1, iBuild := 4, iRevision := 0, sVersion := '0.1.4');
+	{attribute 'const_non_replaced'}
+	stLibVersion_LCLS_General : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/tc_release/tests/test_make_release.py
+++ b/tc_release/tests/test_make_release.py
@@ -81,7 +81,8 @@ def test_dry_run(
     with global_version.open() as fd:
         assert (
             f': ST_LibVersion := (iMajor := {major}, iMinor := {minor}, '
-            f"iBuild := {fix}, iRevision := 0, sVersion := '{version}');"
+            f"iBuild := {fix}, iRevision := 0, nFlags := 1, "
+            f"sVersion := '{version}');"
         ) in fd.read()
 
 


### PR DESCRIPTION
Closes #38 

This replaces the global version file template with an updated one generated from a more recent build of TwinCAT that includes the "no-analysis" pragma, allowing this file to be skipped by static analysis checks during the project build phase. This is required for projects like `lcls-twincat-general` to be buildable on a tag, because otherwise the build will fail because the configured static analysis checks will fail. See linked issue for more information.

This also ensures that the random uuid we insert into the generated file has the same format as the one that would normally be used by TwinCAT: surrounded by brackets.

Here's an example generated file from after the change. It matches the file from the repo issue close enough to make TwinCAT happy and allows us to build and run the tag's unit tests, which previously did not work.

Notable, the encoding is uppercase instead of lowercase, but this doesn't seem to cause any problems.
```
<?xml version='1.0' encoding='UTF-8'?>
<TcPlcObject Version="1.1.0.1">
  <GVL Name="Global_Version" Id="{2a1396ab-a4b8-4f9e-87b3-62a14358ef3b}">
    <Declaration><![CDATA[{attribute 'TcGenerated'}
{attribute 'no-analysis'}
{attribute 'linkalways'}
// This function has been automatically generated from the project information.
VAR_GLOBAL CONSTANT
    {attribute 'const_non_replaced'}
    stLibVersion_LCLS_General : ST_LibVersion := (iMajor := 999, iMinor := 999, iBuild := 999, iRevision := 0, sVersion := '999.999.999');
END_VAR
]]></Declaration>
  </GVL>
</TcPlcObject>
```

I ran the tests offline and they all passed.
I took lcls-twincat-general from the test suite and uploaded it to the CI vm and verified that the CI unit test runner could run the tests and build/install a proper library from the tagged project.